### PR TITLE
Exclude PRs on the user's own repo

### DIFF
--- a/github.go
+++ b/github.go
@@ -149,9 +149,9 @@ func fetchAllPrIssues(username string, client *github.Client) []*github.Issue {
 	nowPage := 100
 	opt := &github.SearchOptions{ListOptions: github.ListOptions{Page: 1, PerPage: 100}}
 	var allIssues []*github.Issue
-	filterContext := fmt.Sprintf("is:pr author:%s is:closed is:merged", username)
+	filterContext := fmt.Sprintf("is:pr author:%s is:closed is:merged -user:%s", username, username)
 	if showAllPR {
-		filterContext = fmt.Sprintf("is:pr author:%s", username)
+		filterContext = fmt.Sprintf("is:pr author:%s -user:%s", username, username)
 	}
 	for {
 		result, _, err := client.Search.Issues(context.Background(), filterContext, opt)


### PR DESCRIPTION
When retrieving pull requests created by a specific user to other repositories, we can use `-user:username` syntax to exclude pull requests made to our own repository. This can reduce irrelevant search results. 

Reference: https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-within-a-users-or-organizations-repositories