### PR TITLE
docs: update readme about workflow permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Add a comment to your `README.md` like this:
 <!--END_SECTION:my_github-->
 ```
 
+- Update your GitHub Actions Workflow permissions
+
+✅ Read and write permissions
+
+> GitHub Menu: Repository's Settings -> Actions -> General -> Workflow permissions
+
 - Write your own `yml` file
 
 [Sample](https://github.com/yihong0618/2021)


### PR DESCRIPTION

GitHub workflow permissions default is `Read`, should update to `Read and write`

<img width="758" alt="image" src="https://github.com/user-attachments/assets/31462ec0-0c2d-44da-b8ed-e0331506df27">

